### PR TITLE
Copy GitHub Actions workflow and gorelease config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,142 @@
+name: release
+on:
+  push:
+    tags:
+    - v*.*.*
+
+permissions:
+  contents: write
+  id-token: write
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  NUGET_FEED_URL: https://api.nuget.org/v3/index.json
+  PROVIDER: pinecone
+  PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
+  PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  PYPI_USERNAME: "__token__"
+  PUBLISH_PYPI: true
+  PUBLISH_NPM: true
+  PUBLISH_NUGET: true
+jobs:
+  publish_binary:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # tag=v5.0.0
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@c5ead9a448b4660cf1e7866ee22e4dc56538031a # tag=v1.10.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Set PreRelease Version
+      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
+    - uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # v3.3.0
+    - uses: anchore/sbom-action/download-syft@5ecf649a417b8ae17dc8383dc32d46c03f2312df # v0.15.1
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # tag=v5.0.0
+      with:
+        args: -p 3 release --rm-dist
+        version: latest
+    - name: Create tag
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # tag=v7.0.1
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/sdk/${{ github.ref_name }}',
+            sha: context.sha
+          })
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.20.x
+  publish_sdk:
+    name: Publish SDKs
+    runs-on: ubuntu-latest
+    needs: publish_binary
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # tag=v5.0.0
+      with:
+        go-version: ${{ matrix.goversion }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@c5ead9a448b4660cf1e7866ee22e4dc56538031a # tag=v1.10.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@b374ceb6168550de27c6eba92e01c1a774040e11 # tag=v2.0.0
+    - name: Setup Node
+      uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # tag=v4.0.1
+      with:
+        node-version: ${{matrix.nodeversion}}
+        registry-url: ${{env.NPM_REGISTRY_URL}}
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # tag=v2.1.0
+      with:
+        dotnet-version: ${{matrix.dotnetverson}}
+    - name: Setup Python
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # tag=v5.0.0
+      with:
+        python-version: ${{matrix.pythonversion}}
+    - name: Build SDK
+      run: make ${{ matrix.language }}_sdk
+    - name: Check worktree clean
+      run: |
+        git update-index -q --refresh
+        if ! git diff-files --quiet; then
+            >&2 echo "error: working tree is not clean, aborting!"
+            git status
+            git diff
+            exit 1
+        fi
+    - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
+      name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # tag=v1.8.11
+      with:
+        user: ${{ env.PYPI_USERNAME }}
+        password: ${{ env.PYPI_PASSWORD }}
+        packages_dir: ${{github.workspace}}/sdk/python/bin/dist
+    - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
+      uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552 # tag=v3.0.1
+      with:
+        access: "public"
+        token: ${{ env.NPM_TOKEN }}
+        package: ${{github.workspace}}/sdk/nodejs/bin/package.json
+        provenance: true
+    - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
+      name: publish nuget package
+      run: |
+        dotnet nuget push ${{github.workspace}}/sdk/dotnet/bin/Debug/*.nupkg -s ${{ env.NUGET_FEED_URL }} -k ${{ env.NUGET_PUBLISH_KEY }}
+        echo "done publishing packages"
+    strategy:
+      fail-fast: true
+      matrix:
+        dotnetversion:
+        - 3.1.301
+        goversion:
+        - 1.20.x
+        language:
+        - nodejs
+        - python
+        - dotnet
+        - go
+        nodeversion:
+        - 18.x
+        pythonversion:
+        - "3.9"


### PR DESCRIPTION
-Prepping for automating releases of the provider

## Problem

We need to wire up automations on our provider repo, and we'd like to automatically publish our releases across PyPi, NPM, etc.

## Solution

Following the instructions in the `deployment-templates` directory, I began this set up, filling in the values I'm already aware of as best I could.

I left options at their default where I'm missing the value.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

We'll ensure that the intended steps (open PR, merge, etc) result in the packages being built and distributed successfully to their respective package manager.
