### PR TITLE
ci: bump jdx/mise-action v3 -> v4

### DIFF
--- a/.github/workflows/check-upgrade-provider.yaml
+++ b/.github/workflows/check-upgrade-provider.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup mise
-      uses: jdx/mise-action@v3
+      uses: jdx/mise-action@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         cache_key: "mise-{{platform}}-{{file_hash}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Setup mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_key: "mise-{{platform}}-{{file_hash}}"
@@ -81,7 +81,7 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Setup mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_key: "mise-{{platform}}-{{file_hash}}"

--- a/.github/workflows/upgrade-provider.yaml
+++ b/.github/workflows/upgrade-provider.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup mise
-      uses: jdx/mise-action@v3
+      uses: jdx/mise-action@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         cache_key: "mise-{{platform}}-{{file_hash}}"


### PR DESCRIPTION
## What

Bumps `jdx/mise-action` from `@v3` to `@v4` (latest is v4.2.4) in the three workflows that still pin v3:

- `.github/workflows/release.yaml` (2 uses)
- `.github/workflows/check-upgrade-provider.yaml`
- `.github/workflows/upgrade-provider.yaml`

## Why

The v3 mise bootstrap (`curl | tar` of the mise binary) intermittently failed with `503`s from the download host, breaking otherwise-green runs. v4 has a newer bootstrap that should be more resilient. The `test` workflow (added in #193) already uses `@v4` and is green; this brings the remaining workflows in line.

## Scope

Version-tag bump only — no behavior or config change. mise still provides the same tools (golangci-lint per `mise.toml`).